### PR TITLE
WIP: Pipe anycast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ An implementation of an asynchronous Unix signal handling backed futures.
 [dependencies]
 tokio-core = "0.1"
 futures = "0.1.7"
+lazy_static = "0.2"
+nix = "0.7"
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ mio = "0.6"
 winapi = "0.2"
 kernel32-sys = "0.2"
 mio = "0.6"
+
+[replace]
+"tokio-core:0.1.3" = { git = "https://github.com/tokio-rs/tokio-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,19 +11,15 @@ An implementation of an asynchronous Unix signal handling backed futures.
 """
 
 [dependencies]
-tokio-core = "0.1"
+tokio-core = "0.1.4"
 futures = "0.1.7"
-lazy_static = "0.2"
-nix = "0.7"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 mio = "0.6"
+mio-uds = "0.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"
 mio = "0.6"
-
-[replace]
-"tokio-core:0.1.3" = { git = "https://github.com/tokio-rs/tokio-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ lazy_static = "0.2"
 nix = "0.7"
 
 [target.'cfg(unix)'.dependencies]
-tokio-uds = "0.1"
 libc = "0.2"
 mio = "0.6"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,6 @@
 #[macro_use]
 extern crate futures;
 extern crate tokio_core;
-#[macro_use]
-extern crate lazy_static;
 
 use futures::Future;
 use futures::stream::Stream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@
 #[macro_use]
 extern crate futures;
 extern crate tokio_core;
+#[macro_use]
+extern crate lazy_static;
 
 use futures::Future;
 use futures::stream::Stream;


### PR DESCRIPTION
This is an attempt at the other approached for #4, as discussed in #5.

It is a prototype-quality code, more a proof of concept than the final implementation, for several reasons:

* It currently depends on tokio-core in master, because of the `CoreId` addition.
* I added the `lazy_static` and `nix` dependencies for now, for faster implementation of the prototype. I'll try to get rid of them later on (but I fear it'll be at the cost of introducing bunch of unsafe blocks).
* There's a bunch of `Mutex`es, maybe this could be done with less of these.
* The documentation isn't updated yet.
* The tests pass with removal of the global loop, but it wouldn't hurt to test the dropping of loops more.
* I probably want to replace the `mpsc` with custom `Stream` implementation (similar to the original), as this generates unneeded wakeups on the sender side.
* Error handling is mostly `unwrap()`. It needs to be decided what to do with errors in what context.
* The sender ends should probably be unregistered once the receiver is dropped, so they don't accumulate if certain kind of signal doesn't come for a long time.