### PR TITLE
Use tokio instead of tokio_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,16 @@ appveyor = { repository = "alexcrichton/tokio-signal" }
 [dependencies]
 futures = "0.1.11"
 mio = "0.6.5"
-tokio-core = "0.1.6"
+tokio-reactor = "0.1.0"
+tokio-executor = "0.1.0"
 tokio-io = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 mio-uds = "0.6"
+
+[dev-dependencies]
+tokio-core = "0.1.17"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ mio-uds = "0.6"
 
 [dev-dependencies]
 tokio-core = "0.1.17"
+tokio = "0.1.0"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/README.md
+++ b/README.md
@@ -19,19 +19,16 @@ Next you can use this in conjunction with the `tokio-core` and `futures` crates:
 
 ```rust,no_run
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_signal;
 
-use tokio_core::reactor::Core;
 use futures::{Future, Stream};
 
 fn main() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
 
     // Create an infinite stream of "Ctrl+C" notifications. Each item received
     // on this stream may represent multiple ctrl-c signals.
-    let ctrl_c = tokio_signal::ctrl_c(&handle).flatten_stream();
+    let ctrl_c = tokio_signal::ctrl_c().flatten_stream();
 
     // Process each ctrl-c as it comes in
     let prog = ctrl_c.for_each(|()| {
@@ -39,7 +36,7 @@ fn main() {
         Ok(())
     });
 
-    core.run(prog).unwrap();
+    tokio::run(prog.map_err(|err| panic!("{}", err)));
 }
 ```
 

--- a/examples/ctrl-c.rs
+++ b/examples/ctrl-c.rs
@@ -19,7 +19,7 @@ fn main() {
     // the `flatten_stream()` convenience method lazily defers that
     // initialisation, allowing us to use it 'as if' it is already the
     // stream we want, reducing boilerplate Future-handling.
-    let endless_stream = tokio_signal::ctrl_c(&core.handle().new_tokio_handle()).flatten_stream();
+    let endless_stream = tokio_signal::ctrl_c().flatten_stream();
     // don't keep going forever: convert the endless stream to a bounded one.
     let limited_stream = endless_stream.take(STOP_AFTER);
 

--- a/examples/ctrl-c.rs
+++ b/examples/ctrl-c.rs
@@ -61,38 +61,3 @@ fn main() {
 
     println!("Stream ended, quiting the program.");
 }
-
-#[cfg(test)]
-// `Child::kill` terminates the application instead of sending the equivalent to SIGKILL on windows
-#[cfg(unix)]
-mod tests {
-    use super::*;
-
-    use std::env;
-    use std::path::Path;
-    use std::process::Command;
-
-    #[test]
-    fn ctrl_c() {
-        let args = env::args().collect::<Vec<_>>();
-        let ctrl_c_child = "ctrl_c_child";
-        if args.len() >= 3 && args.last().map(|s| &s[..]) == Some(ctrl_c_child) {
-            super::main();
-        } else {
-            let ctrl_c_path = Path::new("target")
-                .join("debug")
-                .join("examples")
-                .join("ctrl-c");
-            let mut child = Command::new(ctrl_c_path)
-                .args(&["ctrl_c", "--nocapture", ctrl_c_child])
-                .spawn()
-                .unwrap();
-
-            for i in 0..STOP_AFTER {
-                println!("Kill {}", i);
-                child.kill().unwrap();
-            }
-            child.wait().unwrap();
-        }
-    }
-}

--- a/examples/ctrl-c.rs
+++ b/examples/ctrl-c.rs
@@ -19,7 +19,7 @@ fn main() {
     // the `flatten_stream()` convenience method lazily defers that
     // initialisation, allowing us to use it 'as if' it is already the
     // stream we want, reducing boilerplate Future-handling.
-    let endless_stream = tokio_signal::ctrl_c(&core.handle()).flatten_stream();
+    let endless_stream = tokio_signal::ctrl_c(&core.handle().new_tokio_handle()).flatten_stream();
     // don't keep going forever: convert the endless stream to a bounded one.
     let limited_stream = endless_stream.take(STOP_AFTER);
 

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -11,6 +11,7 @@ use tokio_signal::unix::{Signal, SIGINT, SIGTERM};
 fn main() {
     let mut core = Core::new().unwrap();
     let handle = core.handle();
+    let handle = handle.new_tokio_handle();
 
     // Create a stream for each of the signals we'd like to handle.
     let sigint = Signal::new(SIGINT, &handle).flatten_stream();

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -10,12 +10,10 @@ use tokio_signal::unix::{Signal, SIGINT, SIGTERM};
 
 fn main() {
     let mut core = Core::new().unwrap();
-    let handle = core.handle();
-    let handle = handle.new_tokio_handle();
 
     // Create a stream for each of the signals we'd like to handle.
-    let sigint = Signal::new(SIGINT, &handle).flatten_stream();
-    let sigterm = Signal::new(SIGTERM, &handle).flatten_stream();
+    let sigint = Signal::new(SIGINT).flatten_stream();
+    let sigterm = Signal::new(SIGTERM).flatten_stream();
 
     // Use the `select` combinator to merge these two streams into one
     let stream = sigint.select(sigterm);

--- a/examples/sighup-example.rs
+++ b/examples/sighup-example.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut core = Core::new().unwrap();
 
     // on Unix, we can listen to whatever signal we want, in this case: SIGHUP
-    let stream = Signal::new(SIGHUP, &core.handle()).flatten_stream();
+    let stream = Signal::new(SIGHUP, &core.handle().new_tokio_handle()).flatten_stream();
 
     println!("Waiting for SIGHUPS (Ctrl+C to quit)");
     println!(

--- a/examples/sighup-example.rs
+++ b/examples/sighup-example.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut core = Core::new().unwrap();
 
     // on Unix, we can listen to whatever signal we want, in this case: SIGHUP
-    let stream = Signal::new(SIGHUP, &core.handle().new_tokio_handle()).flatten_stream();
+    let stream = Signal::new(SIGHUP).flatten_stream();
 
     println!("Waiting for SIGHUPS (Ctrl+C to quit)");
     println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,10 @@
 //!
 //! fn main() {
 //!     let mut core = Core::new().unwrap();
-//!     let handle = core.handle();
-//!     let handle = handle.new_tokio_handle();
 //!
 //!     // Create an infinite stream of "Ctrl+C" notifications. Each item received
 //!     // on this stream may represent multiple ctrl-c signals.
-//!     let ctrl_c = tokio_signal::ctrl_c(&handle).flatten_stream();
+//!     let ctrl_c = tokio_signal::ctrl_c().flatten_stream();
 //!
 //!     // Process each ctrl-c as it comes in
 //!     let prog = ctrl_c.for_each(|()| {
@@ -63,12 +61,10 @@
 //!
 //! fn main() {
 //!     let mut core = Core::new().unwrap();
-//!     let handle = core.handle();
-//!     let handle = handle.new_tokio_handle();
 //!
 //!     // Like the previous example, this is an infinite stream of signals
 //!     // being received, and signals may be coalesced while pending.
-//!     let stream = Signal::new(SIGHUP, &handle).flatten_stream();
+//!     let stream = Signal::new(SIGHUP).flatten_stream();
 //!
 //!     // Convert out stream into a future and block the program
 //!     core.run(stream.into_future()).ok().unwrap();
@@ -107,19 +103,34 @@ pub type IoStream<T> = Box<Stream<Item = T, Error = io::Error> + Send>;
 /// event to a console process can be represented as a stream for both Windows
 /// and Unix.
 ///
+/// This function binds to the default event loop. Note that
+/// there are a number of caveats listening for signals, and you may wish to
+/// read up on the documentation in the `unix` or `windows` module to take a
+/// peek.
+pub fn ctrl_c() -> IoFuture<IoStream<()>> {
+    ctrl_c_handle(&Handle::current())
+}
+
+/// Creates a stream which receives "ctrl-c" notifications sent to a process.
+///
+/// In general signals are handled very differently across Unix and Windows, but
+/// this is somewhat cross platform in terms of how it can be handled. A ctrl-c
+/// event to a console process can be represented as a stream for both Windows
+/// and Unix.
+///
 /// This function receives a `Handle` to an event loop and returns a future
 /// which when resolves yields a stream receiving all signal events. Note that
 /// there are a number of caveats listening for signals, and you may wish to
 /// read up on the documentation in the `unix` or `windows` module to take a
 /// peek.
-pub fn ctrl_c(handle: &Handle) -> IoFuture<IoStream<()>> {
+pub fn ctrl_c_handle(handle: &Handle) -> IoFuture<IoStream<()>> {
     return ctrl_c_imp(handle);
 
     #[cfg(unix)]
     fn ctrl_c_imp(handle: &Handle) -> IoFuture<IoStream<()>> {
         let handle = handle.clone();
         Box::new(future::lazy(move || {
-            unix::Signal::new(unix::libc::SIGINT, &handle)
+            unix::Signal::with_handle(unix::libc::SIGINT, &handle)
                 .map(|x| Box::new(x.map(|_| ())) as Box<Stream<Item = _, Error = _> + Send>)
         }))
     }
@@ -129,7 +140,7 @@ pub fn ctrl_c(handle: &Handle) -> IoFuture<IoStream<()>> {
         let handle = handle.clone();
         // Use lazy to ensure that `ctrl_c` gets called while on an event loop
         Box::new(future::lazy(move || {
-            windows::Event::ctrl_c(&handle)
+            windows::Event::ctrl_c_handle(&handle)
                 .map(|x| Box::new(x) as Box<Stream<Item = _, Error = _> + Send>)
         }))
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -347,6 +347,28 @@ impl Signal {
     /// Creates a new stream which will receive notifications when the current
     /// process receives the signal `signal`.
     ///
+    /// This function will create a new stream which binds to the default event
+    /// loop. This function returns a future which will
+    /// then resolve to the signal stream, if successful.
+    ///
+    /// The `Signal` stream is an infinite stream which will receive
+    /// notifications whenever a signal is received. More documentation can be
+    /// found on `Signal` itself, but to reiterate:
+    ///
+    /// * Signals may be coalesced beyond what the kernel already does.
+    /// * Once a signal handler is registered with the process the underlying
+    ///   libc signal handler is never unregistered.
+    ///
+    /// A `Signal` stream can be created for a particular signal number
+    /// multiple times. When a signal is received then all the associated
+    /// channels will receive the signal notification.
+    pub fn new(signal: c_int) -> IoFuture<Signal> {
+        Signal::with_handle(signal, &Handle::current())
+    }
+
+    /// Creates a new stream which will receive notifications when the current
+    /// process receives the signal `signal`.
+    ///
     /// This function will create a new stream which may be based on the
     /// event loop handle provided. This function returns a future which will
     /// then resolve to the signal stream, if successful.
@@ -362,7 +384,7 @@ impl Signal {
     /// A `Signal` stream can be created for a particular signal number
     /// multiple times. When a signal is received then all the associated
     /// channels will receive the signal notification.
-    pub fn new(signal: c_int, handle: &Handle) -> IoFuture<Signal> {
+    pub fn with_handle(signal: c_int, handle: &Handle) -> IoFuture<Signal> {
         let handle = handle.clone();
         Box::new(future::lazy(move || {
             let result = (|| {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -84,7 +84,15 @@ impl Event {
     ///
     /// This function will register a handler via `SetConsoleCtrlHandler` and
     /// deliver notifications to the returned stream.
-    pub fn ctrl_c(handle: &Handle) -> IoFuture<Event> {
+    pub fn ctrl_c() -> IoFuture<Event> {
+        Event::ctrl_c_handle(&Handle::current())
+    }
+
+    /// Creates a new stream listening for the `CTRL_C_EVENT` events.
+    ///
+    /// This function will register a handler via `SetConsoleCtrlHandler` and
+    /// deliver notifications to the returned stream.
+    pub fn ctrl_c_handle(handle: &Handle) -> IoFuture<Event> {
         Event::new(CTRL_C_EVENT, handle)
     }
 
@@ -92,7 +100,15 @@ impl Event {
     ///
     /// This function will register a handler via `SetConsoleCtrlHandler` and
     /// deliver notifications to the returned stream.
-    pub fn ctrl_break(handle: &Handle) -> IoFuture<Event> {
+    pub fn ctrl_break() -> IoFuture<Event> {
+        Event::ctrl_break_handle(&Handle::current())
+    }
+
+    /// Creates a new stream listening for the `CTRL_BREAK_EVENT` events.
+    ///
+    /// This function will register a handler via `SetConsoleCtrlHandler` and
+    /// deliver notifications to the returned stream.
+    pub fn ctrl_break_handle(handle: &Handle) -> IoFuture<Event> {
         Event::new(CTRL_BREAK_EVENT, handle)
     }
 


### PR DESCRIPTION
- [x] Update Windows implementation
- [x] Update unix implementation

This updates the library to use `tokio` instead of `tokio_core`. `tokio_core` can still be used however as it is based on `tokio`. Some breaking changes has been necessary due to changes in the `tokio` API but it should be relatively painless to update.

Of special note is that I had to make the unix implementation create one `Driver` for each created stream as `CoreId` does not exist to let it be done once per event loop (see https://github.com/alexcrichton/tokio-signal/pull/24/commits/296b201952b67941b29fdec54f602d92e11e31dd). This also avoids the issue of how `tokio::run` does not shutdown until all futures are finished.

BREAKING CHANGE

- All functions taking a handle now takes a `tokio_reactor::Handle` instead of `tokio_core::Handle`
- All public methods that previously take a `Handle` have been renamed to methods with a `_handle` suffix. The names for these methods have been reused as functions which takes an implicit handle instead.