### PR TITLE
Version 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+<a name="v0.2.0"></a>
+## v0.2.0 (2018-05-07)
+
+#### Features
+ * Uses `tokio` instead of `tokio_core` (#24)
+ * Supports all 33 signals on FreeBSD (#27)
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-signal"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/tokio-signal"


### PR DESCRIPTION
- Uses `tokio` instead of `tokio_core` (#24)
- Supports all 33 signals on FreeBSD (#27)

Closes #22