### PR TITLE
Update mio dependency to 0.6.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ appveyor = { repository = "alexcrichton/tokio-signal" }
 
 [dependencies]
 futures = "0.1.11"
-mio = "0.6.5"
+mio = "0.6.14"
 tokio-reactor = "0.1.0"
 tokio-executor = "0.1.0"
 tokio-io = "0.1"


### PR DESCRIPTION
This allows tokio-signal to build with `-Z minimal-versions` - see
https://github.com/rust-lang/cargo/issues/5657#issuecomment-401110172
for more details.

Earlier versions depend on log 0.3.1, which itself depends on libc
0.1, which doesn't build on any post-1.0 version of rust.