### PR TITLE
Split up all integration tests to run in their own process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - travis-cargo --only nightly doc-upload
 
 script:
-  - cargo test
+  - cargo test --no-fail-fast
   - rustdoc --test README.md -L target/debug/deps
 
 env:

--- a/tests/drop_then_get_a_signal.rs
+++ b/tests/drop_then_get_a_signal.rs
@@ -1,0 +1,28 @@
+#![cfg(unix)]
+
+extern crate futures;
+extern crate libc;
+extern crate tokio;
+extern crate tokio_core;
+extern crate tokio_signal;
+
+use std::time::Duration;
+
+use tokio_core::reactor::{Core, Timeout};
+use tokio_signal::unix::Signal;
+
+#[test]
+fn drop_then_get_a_signal() {
+    let mut lp = Core::new().unwrap();
+    let handle = lp.handle();
+    let signal = lp.run(Signal::with_handle(
+        libc::SIGUSR1,
+        &handle.new_tokio_handle(),
+    )).unwrap();
+    drop(signal);
+    unsafe {
+        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR1), 0);
+    }
+    let timeout = Timeout::new(Duration::from_millis(1), &lp.handle()).unwrap();
+    lp.run(timeout).unwrap();
+}

--- a/tests/multi_loop.rs
+++ b/tests/multi_loop.rs
@@ -1,0 +1,47 @@
+#![cfg(unix)]
+
+extern crate futures;
+extern crate libc;
+extern crate tokio;
+extern crate tokio_core;
+extern crate tokio_signal;
+
+use std::sync::mpsc::channel;
+use std::thread;
+
+use futures::stream::Stream;
+use tokio_core::reactor::Core;
+use tokio_signal::unix::Signal;
+
+#[test]
+fn multi_loop() {
+    // An "ordinary" (non-future) channel
+    let (sender, receiver) = channel();
+    // Run multiple times, to make sure there are no race conditions
+    for _ in 0..10 {
+        // Run multiple event loops, each one in its own thread
+        let threads: Vec<_> = (0..4)
+            .map(|_| {
+                let sender = sender.clone();
+                thread::spawn(move || {
+                    let mut lp = Core::new().unwrap();
+                    let signal = lp.run(Signal::new(libc::SIGHUP)).unwrap();
+                    sender.send(()).unwrap();
+                    lp.run(signal.into_future()).ok().unwrap();
+                })
+            })
+            .collect();
+        // Wait for them to declare they're ready
+        for &_ in threads.iter() {
+            receiver.recv().unwrap();
+        }
+        // Send a signal
+        unsafe {
+            assert_eq!(libc::kill(libc::getpid(), libc::SIGHUP), 0);
+        }
+        // Make sure the threads terminated correctly
+        for t in threads {
+            t.join().unwrap();
+        }
+    }
+}

--- a/tests/notify_both.rs
+++ b/tests/notify_both.rs
@@ -1,0 +1,32 @@
+#![cfg(unix)]
+
+extern crate futures;
+extern crate libc;
+extern crate tokio;
+extern crate tokio_core;
+extern crate tokio_signal;
+
+use futures::stream::Stream;
+use futures::Future;
+use tokio_core::reactor::Core;
+use tokio_signal::unix::Signal;
+
+#[test]
+fn notify_both() {
+    let mut lp = Core::new().unwrap();
+    let handle = lp.handle();
+    let signal1 = lp.run(Signal::with_handle(
+        libc::SIGUSR2,
+        &handle.new_tokio_handle(),
+    )).unwrap();
+    let signal2 = lp.run(Signal::with_handle(
+        libc::SIGUSR2,
+        &handle.new_tokio_handle(),
+    )).unwrap();
+    unsafe {
+        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR2), 0);
+    }
+    lp.run(signal1.into_future().join(signal2.into_future()))
+        .ok()
+        .unwrap();
+}

--- a/tests/signal.rs
+++ b/tests/signal.rs
@@ -6,24 +6,9 @@ extern crate tokio;
 extern crate tokio_core;
 extern crate tokio_signal;
 
-use std::sync::mpsc::channel;
-use std::thread;
-use std::time::Duration;
-
 use futures::stream::Stream;
 use futures::{Future, IntoFuture};
-use tokio_core::reactor::{Core, Timeout};
 use tokio_signal::unix::Signal;
-
-#[test]
-fn simple() {
-    let mut lp = Core::new().unwrap();
-    let signal = lp.run(Signal::new(libc::SIGUSR1)).unwrap();
-    unsafe {
-        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR1), 0);
-    }
-    lp.run(signal.into_future()).ok().unwrap();
-}
 
 #[test]
 fn tokio_simple() {
@@ -38,88 +23,4 @@ fn tokio_simple() {
             })
             .map_err(|err| panic!("{}", err)),
     )
-}
-
-#[test]
-fn notify_both() {
-    let mut lp = Core::new().unwrap();
-    let handle = lp.handle();
-    let signal1 = lp.run(Signal::with_handle(
-        libc::SIGUSR2,
-        &handle.new_tokio_handle(),
-    )).unwrap();
-    let signal2 = lp.run(Signal::with_handle(
-        libc::SIGUSR2,
-        &handle.new_tokio_handle(),
-    )).unwrap();
-    unsafe {
-        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR2), 0);
-    }
-    lp.run(signal1.into_future().join(signal2.into_future()))
-        .ok()
-        .unwrap();
-}
-
-#[test]
-fn drop_then_get_a_signal() {
-    let mut lp = Core::new().unwrap();
-    let handle = lp.handle();
-    let signal = lp.run(Signal::with_handle(
-        libc::SIGUSR1,
-        &handle.new_tokio_handle(),
-    )).unwrap();
-    drop(signal);
-    unsafe {
-        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR1), 0);
-    }
-    let timeout = Timeout::new(Duration::from_millis(1), &lp.handle()).unwrap();
-    lp.run(timeout).unwrap();
-}
-
-#[test]
-fn twice() {
-    let mut lp = Core::new().unwrap();
-    let signal = lp.run(Signal::new(libc::SIGUSR1)).unwrap();
-    unsafe {
-        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR1), 0);
-    }
-    let (num, signal) = lp.run(signal.into_future()).ok().unwrap();
-    assert_eq!(num, Some(libc::SIGUSR1));
-    unsafe {
-        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR1), 0);
-    }
-    lp.run(signal.into_future()).ok().unwrap();
-}
-
-#[test]
-fn multi_loop() {
-    // An "ordinary" (non-future) channel
-    let (sender, receiver) = channel();
-    // Run multiple times, to make sure there are no race conditions
-    for _ in 0..10 {
-        // Run multiple event loops, each one in its own thread
-        let threads: Vec<_> = (0..4)
-            .map(|_| {
-                let sender = sender.clone();
-                thread::spawn(move || {
-                    let mut lp = Core::new().unwrap();
-                    let signal = lp.run(Signal::new(libc::SIGHUP)).unwrap();
-                    sender.send(()).unwrap();
-                    lp.run(signal.into_future()).ok().unwrap();
-                })
-            })
-            .collect();
-        // Wait for them to declare they're ready
-        for &_ in threads.iter() {
-            receiver.recv().unwrap();
-        }
-        // Send a signal
-        unsafe {
-            assert_eq!(libc::kill(libc::getpid(), libc::SIGHUP), 0);
-        }
-        // Make sure the threads terminated correctly
-        for t in threads {
-            t.join().unwrap();
-        }
-    }
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,0 +1,20 @@
+#![cfg(unix)]
+
+extern crate futures;
+extern crate libc;
+extern crate tokio_core;
+extern crate tokio_signal;
+
+use futures::stream::Stream;
+use tokio_core::reactor::Core;
+use tokio_signal::unix::Signal;
+
+#[test]
+fn simple() {
+    let mut lp = Core::new().unwrap();
+    let signal = lp.run(Signal::new(libc::SIGUSR1)).unwrap();
+    unsafe {
+        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR1), 0);
+    }
+    lp.run(signal.into_future()).ok().unwrap();
+}

--- a/tests/twice.rs
+++ b/tests/twice.rs
@@ -1,0 +1,26 @@
+#![cfg(unix)]
+
+extern crate futures;
+extern crate libc;
+extern crate tokio;
+extern crate tokio_core;
+extern crate tokio_signal;
+
+use futures::stream::Stream;
+use tokio_core::reactor::Core;
+use tokio_signal::unix::Signal;
+
+#[test]
+fn twice() {
+    let mut lp = Core::new().unwrap();
+    let signal = lp.run(Signal::new(libc::SIGUSR1)).unwrap();
+    unsafe {
+        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR1), 0);
+    }
+    let (num, signal) = lp.run(signal.into_future()).ok().unwrap();
+    assert_eq!(num, Some(libc::SIGUSR1));
+    unsafe {
+        assert_eq!(libc::kill(libc::getpid(), libc::SIGUSR1), 0);
+    }
+    lp.run(signal.into_future()).ok().unwrap();
+}


### PR DESCRIPTION
* Cargo runs each integration-style-test in its own process. Since the
tests use global data structures specific to the process, we should run
them in an isolated manner to avoid having cross-test interactions
* No changes have been made to the actual tests themselves, just a simple cut-and-paste
* Fixes #39