### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,25 @@
-<a name="v0.2.0"></a>
-## v0.2.0 (2018-05-07)
+# Changelog
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2] -
+### Fixes
+* Fix starvation of `Signal`s whenever a `Signal` instance is dropped
+* Fix starvation of individual `Signal`s based on their creation order
+
+## [0.2.1] - 2018-05-27
+### Fixes
+* Bump minimum supported version of `mio` to 0.6.14
+
+## 0.2.0 - 2018-05-07
 #### Features
  * Uses `tokio` instead of `tokio_core` (#24)
  * Supports all 33 signals on FreeBSD (#27)
 
+[Unreleased]: https://github.com/alexcrichton/tokio-process/compare/0.2.2...HEAD
+[0.2.2]: https://github.com/alexcrichton/tokio-signal/compare/0.2.1...0.2.2
+[0.2.1]: https://github.com/alexcrichton/tokio-signal/compare/0.2.0...0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tokio-signal"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/tokio-signal"
 homepage = "https://github.com/alexcrichton/tokio-signal"
-documentation = "https://docs.rs/tokio-signal/0.1"
+documentation = "https://docs.rs/tokio-signal/0.2"
 description = """
 An implementation of an asynchronous Unix signal handling backed futures.
 """

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //! # fn main() {}
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/tokio-signal/0.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-signal/0.2")]
 #![deny(missing_docs)]
 
 extern crate futures;


### PR DESCRIPTION
* Bump the version to 0.2.2 and prepare for a new release
* This will formally publish fixes for #36 and #38 

r + publish? @alexcrichton 