### PR TITLE
Use signal-hook for registration of signals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokio-io = "0.1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 mio-uds = "0.6"
+signal-hook = "0.1"
 
 [dev-dependencies]
 tokio-core = "0.1.17"


### PR DESCRIPTION
This saves some code and gets rid of quite some amount of unsafe code.

This is related to #45. As a first step, I've only replaced the registration and I'd think if some more code can be simplified or reused with signal-hook.

I've noticed one thing in the process. Signal-hook refuses to register certain signals (https://docs.rs/signal-hook/0.1.4/signal_hook/fn.register.html#panics). Is that a problem? I don't think it is (as listed in the link, these won't do what you want with tokio-signal either).